### PR TITLE
Rename common config keys

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -27,18 +27,18 @@ const (
 )
 
 const (
-	// ConfigKeyAddress is a config name for an address.
-	ConfigKeyAddress = "address"
-	// ConfigKeyTable is a config name for an table.
-	ConfigKeyTable = "table"
+	// KeyAddress is a config name for an address.
+	KeyAddress = "address"
+	// KeyTable is a config name for an table.
+	KeyTable = "table"
 	// ConfigKeyKey is a config name for an key column.
-	ConfigKeyKeyColumn = "keyColumn"
-	// ConfigKeyUsername is a config name for an username.
-	ConfigKeyUsername = "username"
-	// ConfigKeyPassword is a config name for an password.
-	ConfigKeyPassword = "password"
-	// ConfigKeyTarget is a config name for an target.
-	ConfigKeyTarget = "target"
+	KeyKeyColumn = "keyColumn"
+	// KeyUsername is a config name for an username.
+	KeyUsername = "username"
+	// KeyPassword is a config name for an password.
+	KeyPassword = "password"
+	// KeyTarget is a config name for an target.
+	KeyTarget = "target"
 )
 
 // Config contains configurable values
@@ -66,12 +66,12 @@ type Config struct {
 // Parse attempts to parse a provided map[string]string into a Config struct.
 func Parse(cfg map[string]string) (Config, error) {
 	config := Config{
-		Address:   cfg[ConfigKeyAddress],
-		Table:     strings.ToLower(cfg[ConfigKeyTable]),
-		KeyColumn: strings.ToLower(cfg[ConfigKeyKeyColumn]),
-		Username:  cfg[ConfigKeyUsername],
-		Password:  cfg[ConfigKeyPassword],
-		Target:    cfg[ConfigKeyTarget],
+		Address:   cfg[KeyAddress],
+		Table:     strings.ToLower(cfg[KeyTable]),
+		KeyColumn: strings.ToLower(cfg[KeyKeyColumn]),
+		Username:  cfg[KeyUsername],
+		Password:  cfg[KeyPassword],
+		Target:    cfg[KeyTarget],
 	}
 
 	config.setDefaults()

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -35,9 +35,9 @@ func TestParse(t *testing.T) {
 			name: "success, required and default fields",
 			args: args{
 				cfg: map[string]string{
-					ConfigKeyAddress:   "localhost:15991",
-					ConfigKeyTable:     "users",
-					ConfigKeyKeyColumn: "id",
+					KeyAddress:   "localhost:15991",
+					KeyTable:     "users",
+					KeyKeyColumn: "id",
 				},
 			},
 			want: Config{
@@ -52,11 +52,11 @@ func TestParse(t *testing.T) {
 			name: "success, required, default and auth fields",
 			args: args{
 				cfg: map[string]string{
-					ConfigKeyAddress:   "localhost:15991",
-					ConfigKeyTable:     "users",
-					ConfigKeyKeyColumn: "id",
-					ConfigKeyUsername:  "admin",
-					ConfigKeyPassword:  "super_secret",
+					KeyAddress:   "localhost:15991",
+					KeyTable:     "users",
+					KeyKeyColumn: "id",
+					KeyUsername:  "admin",
+					KeyPassword:  "super_secret",
 				},
 			},
 			want: Config{
@@ -73,12 +73,12 @@ func TestParse(t *testing.T) {
 			name: "success, required, auth and custom target fields",
 			args: args{
 				cfg: map[string]string{
-					ConfigKeyAddress:   "localhost:15991",
-					ConfigKeyTable:     "users",
-					ConfigKeyKeyColumn: "id",
-					ConfigKeyUsername:  "admin",
-					ConfigKeyPassword:  "super_secret",
-					ConfigKeyTarget:    "@replica",
+					KeyAddress:   "localhost:15991",
+					KeyTable:     "users",
+					KeyKeyColumn: "id",
+					KeyUsername:  "admin",
+					KeyPassword:  "super_secret",
+					KeyTarget:    "@replica",
 				},
 			},
 			want: Config{
@@ -95,9 +95,9 @@ func TestParse(t *testing.T) {
 			name: "fail, invalid address, redundant scheme",
 			args: args{
 				cfg: map[string]string{
-					ConfigKeyAddress:   "http://localhost:15991",
-					ConfigKeyTable:     "users",
-					ConfigKeyKeyColumn: "id",
+					KeyAddress:   "http://localhost:15991",
+					KeyTable:     "users",
+					KeyKeyColumn: "id",
 				},
 			},
 			want:    Config{},
@@ -107,9 +107,9 @@ func TestParse(t *testing.T) {
 			name: "fail, invalid address, port is missing",
 			args: args{
 				cfg: map[string]string{
-					ConfigKeyAddress:   "localhost:",
-					ConfigKeyTable:     "users",
-					ConfigKeyKeyColumn: "id",
+					KeyAddress:   "localhost:",
+					KeyTable:     "users",
+					KeyKeyColumn: "id",
 				},
 			},
 			want:    Config{},
@@ -119,9 +119,9 @@ func TestParse(t *testing.T) {
 			name: "fail, invalid address, only host",
 			args: args{
 				cfg: map[string]string{
-					ConfigKeyAddress:   "localhost:",
-					ConfigKeyTable:     "users",
-					ConfigKeyKeyColumn: "id",
+					KeyAddress:   "localhost:",
+					KeyTable:     "users",
+					KeyKeyColumn: "id",
 				},
 			},
 			want:    Config{},
@@ -131,9 +131,9 @@ func TestParse(t *testing.T) {
 			name: "fail, invalid table name, length is greater than 64",
 			args: args{
 				cfg: map[string]string{
-					ConfigKeyAddress:   "localhost:15991",
-					ConfigKeyTable:     "ABRATQkOlvPWqfTgUssUuGYCVkQJd4YlkQ1BEe51cctLMqCzjLanlwARrlXZVmd4vbJLne",
-					ConfigKeyKeyColumn: "id",
+					KeyAddress:   "localhost:15991",
+					KeyTable:     "ABRATQkOlvPWqfTgUssUuGYCVkQJd4YlkQ1BEe51cctLMqCzjLanlwARrlXZVmd4vbJLne",
+					KeyKeyColumn: "id",
 				},
 			},
 			want:    Config{},
@@ -143,9 +143,9 @@ func TestParse(t *testing.T) {
 			name: "fail, invalid keyColumn name, length is greater than 64",
 			args: args{
 				cfg: map[string]string{
-					ConfigKeyAddress:   "localhost:15991",
-					ConfigKeyTable:     "users",
-					ConfigKeyKeyColumn: "RgRGxUoqE2py3swvXKkuR4d88OFs4hDwReY77sltzmPo6KS8aXDqk1ZN7AR5YgW5nV9OAe",
+					KeyAddress:   "localhost:15991",
+					KeyTable:     "users",
+					KeyKeyColumn: "RgRGxUoqE2py3swvXKkuR4d88OFs4hDwReY77sltzmPo6KS8aXDqk1ZN7AR5YgW5nV9OAe",
 				},
 			},
 			want:    Config{},

--- a/destination/destination_integration_test.go
+++ b/destination/destination_integration_test.go
@@ -50,7 +50,7 @@ func TestDestination_Write_Success(t *testing.T) {
 	is.NoErr(err)
 
 	t.Cleanup(func() {
-		err := clearData(ctx, db, cfg[config.ConfigKeyTable])
+		err := clearData(ctx, db, cfg[config.KeyTable])
 		is.NoErr(err)
 
 		db.Close()
@@ -95,7 +95,7 @@ func TestDestination_Write_Success(t *testing.T) {
 		is.NoErr(err)
 
 		row := db.QueryRowContext(context.Background(),
-			fmt.Sprintf(querySelectEmail, cfg[config.ConfigKeyTable], 1),
+			fmt.Sprintf(querySelectEmail, cfg[config.KeyTable], 1),
 		)
 
 		var email string
@@ -125,7 +125,7 @@ func TestDestination_Write_Success(t *testing.T) {
 		is.NoErr(err)
 
 		row := db.QueryRowContext(context.Background(),
-			fmt.Sprintf(querySelectEmail, cfg[config.ConfigKeyTable], 1),
+			fmt.Sprintf(querySelectEmail, cfg[config.KeyTable], 1),
 		)
 
 		var email string
@@ -154,7 +154,7 @@ func TestDestination_Write_Success(t *testing.T) {
 		is.NoErr(err)
 
 		row := db.QueryRowContext(context.Background(),
-			fmt.Sprintf(querySelectEmail, cfg[config.ConfigKeyTable], 1),
+			fmt.Sprintf(querySelectEmail, cfg[config.KeyTable], 1),
 		)
 
 		err = row.Scan()
@@ -180,7 +180,7 @@ func TestDestination_Write_Failed(t *testing.T) {
 	is.NoErr(err)
 
 	t.Cleanup(func() {
-		err := clearData(ctx, db, cfg[config.ConfigKeyTable])
+		err := clearData(ctx, db, cfg[config.KeyTable])
 		is.NoErr(err)
 
 		db.Close()
@@ -211,16 +211,16 @@ func TestDestination_Write_Failed(t *testing.T) {
 // prepareConfig prepares a test config.
 func prepareConfig() map[string]string {
 	return map[string]string{
-		config.ConfigKeyAddress:   "localhost:33575",
-		config.ConfigKeyTable:     generateTableName(),
-		config.ConfigKeyKeyColumn: "customer_id",
-		config.ConfigKeyTarget:    "test@primary",
+		config.KeyAddress:   "localhost:33575",
+		config.KeyTable:     generateTableName(),
+		config.KeyKeyColumn: "customer_id",
+		config.KeyTarget:    "test@primary",
 	}
 }
 
 // prepareData connects to a test vtgate instance, creates a test table and returns the *sql.DB.
 func prepareData(ctx context.Context, cfg map[string]string) (*sql.DB, error) {
-	db, err := vitessdriver.Open(cfg[config.ConfigKeyAddress], cfg[config.ConfigKeyTarget])
+	db, err := vitessdriver.Open(cfg[config.KeyAddress], cfg[config.KeyTarget])
 	if err != nil {
 		return nil, fmt.Errorf("connector to vtgate: %w", err)
 	}
@@ -229,12 +229,12 @@ func prepareData(ctx context.Context, cfg map[string]string) (*sql.DB, error) {
 		return nil, fmt.Errorf("ping vtgate: %w", err)
 	}
 
-	_, err = db.ExecContext(ctx, fmt.Sprintf(queryCreateTable, cfg[config.ConfigKeyTable]))
+	_, err = db.ExecContext(ctx, fmt.Sprintf(queryCreateTable, cfg[config.KeyTable]))
 	if err != nil {
 		return nil, fmt.Errorf("exec create table query: %w", err)
 	}
 
-	_, err = db.ExecContext(ctx, fmt.Sprintf(queryCreateVindex, cfg[config.ConfigKeyTable]))
+	_, err = db.ExecContext(ctx, fmt.Sprintf(queryCreateVindex, cfg[config.KeyTable]))
 	if err != nil {
 		return nil, fmt.Errorf("exec create vindex query: %w", err)
 	}

--- a/destination/destination_test.go
+++ b/destination/destination_test.go
@@ -43,12 +43,12 @@ func TestDestination_Configure(t *testing.T) {
 			name: "success",
 			args: args{
 				cfg: map[string]string{
-					config.ConfigKeyAddress:   "localhost:15991",
-					config.ConfigKeyTable:     "users",
-					config.ConfigKeyKeyColumn: "id",
-					config.ConfigKeyUsername:  "admin",
-					config.ConfigKeyPassword:  "super_secret",
-					config.ConfigKeyTarget:    "@replica",
+					config.KeyAddress:   "localhost:15991",
+					config.KeyTable:     "users",
+					config.KeyKeyColumn: "id",
+					config.KeyUsername:  "admin",
+					config.KeyPassword:  "super_secret",
+					config.KeyTarget:    "@replica",
 				},
 			},
 			wantErr: false,
@@ -57,8 +57,8 @@ func TestDestination_Configure(t *testing.T) {
 			name: "fail, missing address",
 			args: args{
 				cfg: map[string]string{
-					config.ConfigKeyTable:     "users",
-					config.ConfigKeyKeyColumn: "id",
+					config.KeyTable:     "users",
+					config.KeyKeyColumn: "id",
 				},
 			},
 			wantErr: true,
@@ -67,9 +67,9 @@ func TestDestination_Configure(t *testing.T) {
 			name: "fail, invalid address",
 			args: args{
 				cfg: map[string]string{
-					config.ConfigKeyAddress:   "localhost:",
-					config.ConfigKeyTable:     "users",
-					config.ConfigKeyKeyColumn: "id",
+					config.KeyAddress:   "localhost:",
+					config.KeyTable:     "users",
+					config.KeyKeyColumn: "id",
 				},
 			},
 			wantErr: true,
@@ -78,9 +78,9 @@ func TestDestination_Configure(t *testing.T) {
 			name: "fail, invalid table",
 			args: args{
 				cfg: map[string]string{
-					config.ConfigKeyAddress:   "localhost:15991",
-					config.ConfigKeyTable:     "ABRATQkOlvPWqfTgUssUuGYCVkQJd4YlkQ1BEe51cctLMqCzjLanlwARrlXZVmd4vbJLne",
-					config.ConfigKeyKeyColumn: "id",
+					config.KeyAddress:   "localhost:15991",
+					config.KeyTable:     "ABRATQkOlvPWqfTgUssUuGYCVkQJd4YlkQ1BEe51cctLMqCzjLanlwARrlXZVmd4vbJLne",
+					config.KeyKeyColumn: "id",
 				},
 			},
 			wantErr: true,
@@ -89,8 +89,8 @@ func TestDestination_Configure(t *testing.T) {
 			name: "fail, missing table",
 			args: args{
 				cfg: map[string]string{
-					config.ConfigKeyAddress:   "localhost:15991",
-					config.ConfigKeyKeyColumn: "id",
+					config.KeyAddress:   "localhost:15991",
+					config.KeyKeyColumn: "id",
 				},
 			},
 			wantErr: true,
@@ -99,9 +99,9 @@ func TestDestination_Configure(t *testing.T) {
 			name: "fail, invalid key column",
 			args: args{
 				cfg: map[string]string{
-					config.ConfigKeyAddress:   "localhost:15991",
-					config.ConfigKeyTable:     "users",
-					config.ConfigKeyKeyColumn: "ABRATQkOlvPWqfTgUssUuGYCVkQJd4YlkQ1BEe51cctLMqCzjLanlwARrlXZVmd4vbJLne",
+					config.KeyAddress:   "localhost:15991",
+					config.KeyTable:     "users",
+					config.KeyKeyColumn: "ABRATQkOlvPWqfTgUssUuGYCVkQJd4YlkQ1BEe51cctLMqCzjLanlwARrlXZVmd4vbJLne",
 				},
 			},
 			wantErr: true,
@@ -110,8 +110,8 @@ func TestDestination_Configure(t *testing.T) {
 			name: "fail, missing key column",
 			args: args{
 				cfg: map[string]string{
-					config.ConfigKeyAddress: "localhost:15991",
-					config.ConfigKeyTable:   "users",
+					config.KeyAddress: "localhost:15991",
+					config.KeyTable:   "users",
 				},
 			},
 			wantErr: true,

--- a/source/config_test.go
+++ b/source/config_test.go
@@ -37,12 +37,12 @@ func TestParseConfig(t *testing.T) {
 			name: "success, all fields",
 			args: args{
 				cfg: map[string]string{
-					config.ConfigKeyAddress:   "localhost:15999",
-					config.ConfigKeyTable:     "users",
-					config.ConfigKeyKeyColumn: "id",
-					ConfigKeyOrderingColumn:   "id",
-					ConfigKeyColumns:          "id,name,age",
-					ConfigKeyBatchSize:        "200",
+					config.KeyAddress:       "localhost:15999",
+					config.KeyTable:         "users",
+					config.KeyKeyColumn:     "id",
+					ConfigKeyOrderingColumn: "id",
+					ConfigKeyColumns:        "id,name,age",
+					ConfigKeyBatchSize:      "200",
 				},
 			},
 			want: Config{
@@ -62,10 +62,10 @@ func TestParseConfig(t *testing.T) {
 			name: "success, only required fields",
 			args: args{
 				cfg: map[string]string{
-					config.ConfigKeyAddress:   "localhost:15999",
-					config.ConfigKeyTable:     "users",
-					config.ConfigKeyKeyColumn: "id",
-					ConfigKeyOrderingColumn:   "id",
+					config.KeyAddress:       "localhost:15999",
+					config.KeyTable:         "users",
+					config.KeyKeyColumn:     "id",
+					ConfigKeyOrderingColumn: "id",
 				},
 			},
 			want: Config{
@@ -84,10 +84,10 @@ func TestParseConfig(t *testing.T) {
 			name: "fail, ordering column is invalid",
 			args: args{
 				cfg: map[string]string{
-					config.ConfigKeyAddress:   "localhost:15999",
-					config.ConfigKeyTable:     "users",
-					config.ConfigKeyKeyColumn: "id",
-					ConfigKeyOrderingColumn:   "verylongnameinordertofailthetestverylongnameinordertofailthetesta",
+					config.KeyAddress:       "localhost:15999",
+					config.KeyTable:         "users",
+					config.KeyKeyColumn:     "id",
+					ConfigKeyOrderingColumn: "verylongnameinordertofailthetestverylongnameinordertofailthetesta",
 				},
 			},
 			want:    Config{},
@@ -97,9 +97,9 @@ func TestParseConfig(t *testing.T) {
 			name: "fail, ordering column is missing",
 			args: args{
 				cfg: map[string]string{
-					config.ConfigKeyAddress:   "localhost:15999",
-					config.ConfigKeyTable:     "users",
-					config.ConfigKeyKeyColumn: "id",
+					config.KeyAddress:   "localhost:15999",
+					config.KeyTable:     "users",
+					config.KeyKeyColumn: "id",
 				},
 			},
 			want:    Config{},
@@ -109,11 +109,11 @@ func TestParseConfig(t *testing.T) {
 			name: "fail, columns has an invalid element",
 			args: args{
 				cfg: map[string]string{
-					config.ConfigKeyAddress:   "localhost:15999",
-					config.ConfigKeyTable:     "users",
-					config.ConfigKeyKeyColumn: "id",
-					ConfigKeyOrderingColumn:   "id",
-					ConfigKeyColumns:          "id,verylongnameinordertofailthetestverylongnameinordertofailthetesta",
+					config.KeyAddress:       "localhost:15999",
+					config.KeyTable:         "users",
+					config.KeyKeyColumn:     "id",
+					ConfigKeyOrderingColumn: "id",
+					ConfigKeyColumns:        "id,verylongnameinordertofailthetestverylongnameinordertofailthetesta",
 				},
 			},
 			want:    Config{},
@@ -123,11 +123,11 @@ func TestParseConfig(t *testing.T) {
 			name: "fail, batchSize is invalid, gte",
 			args: args{
 				cfg: map[string]string{
-					config.ConfigKeyAddress:   "localhost:15999",
-					config.ConfigKeyTable:     "users",
-					config.ConfigKeyKeyColumn: "id",
-					ConfigKeyOrderingColumn:   "id",
-					ConfigKeyBatchSize:        "-1",
+					config.KeyAddress:       "localhost:15999",
+					config.KeyTable:         "users",
+					config.KeyKeyColumn:     "id",
+					ConfigKeyOrderingColumn: "id",
+					ConfigKeyBatchSize:      "-1",
 				},
 			},
 			want:    Config{},
@@ -137,11 +137,11 @@ func TestParseConfig(t *testing.T) {
 			name: "fail, batchSize is invalid, lte",
 			args: args{
 				cfg: map[string]string{
-					config.ConfigKeyAddress:   "localhost:15999",
-					config.ConfigKeyTable:     "users",
-					config.ConfigKeyKeyColumn: "id",
-					ConfigKeyOrderingColumn:   "id",
-					ConfigKeyBatchSize:        "1000000",
+					config.KeyAddress:       "localhost:15999",
+					config.KeyTable:         "users",
+					config.KeyKeyColumn:     "id",
+					ConfigKeyOrderingColumn: "id",
+					ConfigKeyBatchSize:      "1000000",
 				},
 			},
 			want:    Config{},
@@ -151,11 +151,11 @@ func TestParseConfig(t *testing.T) {
 			name: "fail, batchSize is invalid, not a number",
 			args: args{
 				cfg: map[string]string{
-					config.ConfigKeyAddress:   "localhost:15999",
-					config.ConfigKeyTable:     "users",
-					config.ConfigKeyKeyColumn: "id",
-					ConfigKeyOrderingColumn:   "id",
-					ConfigKeyBatchSize:        "one hundred",
+					config.KeyAddress:       "localhost:15999",
+					config.KeyTable:         "users",
+					config.KeyKeyColumn:     "id",
+					ConfigKeyOrderingColumn: "id",
+					ConfigKeyBatchSize:      "one hundred",
 				},
 			},
 			want:    Config{},

--- a/spec.go
+++ b/spec.go
@@ -32,17 +32,17 @@ func Specification() sdk.Specification {
 		Version: "v0.1.0",
 		Author:  "Meroxa, Inc.",
 		SourceParams: map[string]sdk.Parameter{
-			config.ConfigKeyAddress: {
+			config.KeyAddress: {
 				Default:     "",
 				Required:    true,
 				Description: "An address pointed to a VTGate instance.",
 			},
-			config.ConfigKeyTable: {
+			config.KeyTable: {
 				Default:     "",
 				Required:    true,
 				Description: "A name of the table that the connector should write to.",
 			},
-			config.ConfigKeyKeyColumn: {
+			config.KeyKeyColumn: {
 				Default:  "",
 				Required: true,
 				Description: "A column name that used to detect if the target table" +
@@ -53,17 +53,17 @@ func Specification() sdk.Specification {
 				Required:    true,
 				Description: "A name of a column that the connector will use for ordering rows.",
 			},
-			config.ConfigKeyUsername: {
+			config.KeyUsername: {
 				Default:     "",
 				Required:    false,
 				Description: "A username of a VTGate user.",
 			},
-			config.ConfigKeyPassword: {
+			config.KeyPassword: {
 				Default:     "",
 				Required:    false,
 				Description: "A password of a VTGate user.",
 			},
-			config.ConfigKeyTarget: {
+			config.KeyTarget: {
 				Default:     "@primary",
 				Required:    false,
 				Description: "Specifies the VTGate target.",
@@ -80,33 +80,33 @@ func Specification() sdk.Specification {
 			},
 		},
 		DestinationParams: map[string]sdk.Parameter{
-			config.ConfigKeyAddress: {
+			config.KeyAddress: {
 				Default:     "",
 				Required:    true,
 				Description: "An address pointed to a VTGate instance.",
 			},
-			config.ConfigKeyTable: {
+			config.KeyTable: {
 				Default:     "",
 				Required:    true,
 				Description: "A name of the table that the connector should write to.",
 			},
-			config.ConfigKeyKeyColumn: {
+			config.KeyKeyColumn: {
 				Default:  "",
 				Required: true,
 				Description: "A column name that used to detect if the target table" +
 					" already contains the record (destination).",
 			},
-			config.ConfigKeyUsername: {
+			config.KeyUsername: {
 				Default:     "",
 				Required:    false,
 				Description: "A username of a VTGate user.",
 			},
-			config.ConfigKeyPassword: {
+			config.KeyPassword: {
 				Default:     "",
 				Required:    false,
 				Description: "A password of a VTGate user.",
 			},
-			config.ConfigKeyTarget: {
+			config.KeyTarget: {
 				Default:     "@primary",
 				Required:    false,
 				Description: "Specifies the VTGate target.",


### PR DESCRIPTION
### Description

- Rename common config keys

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-s3/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
