### PR TITLE
Add `keyspace` and `tabletType` parameters to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,12 @@ If there is no key, the record will be simply appended.
 
 ## Configuration Options
 
-| name        | description                                                                                               | required | default    |
-| ----------- | --------------------------------------------------------------------------------------------------------- | -------- | ---------- |
-| `address`   | The address pointed to a VTGate instance.<br />Format: `hostname:port`                                    | **true** |            |
-| `table`     | The name of the table that the connector should write to.                                                 | **true** |            |
-| `keyColumn` | Column name used to detect if the target table already contains the record.                               | **true** |            |
-| `username`  | The username of a VTGate user.<br />Required if your VTGate instance has a static authentication enabled. | false    |            |
-| `password`  | The password of a VTGate user.<br />Required if your VTGate instance has a static authentication enabled. | false    |            |
-| `target`    | The target specifies the default target.                                                                  | false    | `@primary` |
+| name         | description                                                                                               | required | default   |
+| ------------ | --------------------------------------------------------------------------------------------------------- | -------- | --------- |
+| `address`    | The address pointed to a VTGate instance.<br />Format: `hostname:port`                                    | **true** |           |
+| `table`      | The name of the table that the connector should write to.                                                 | **true** |           |
+| `keyColumn`  | Column name used to detect if the target table already contains the record.                               | **true** |           |
+| `username`   | The username of a VTGate user.<br />Required if your VTGate instance has a static authentication enabled. | false    |           |
+| `password`   | The password of a VTGate user.<br />Required if your VTGate instance has a static authentication enabled. | false    |           |
+| `keyspace`   | The keyspace specifies a VTGate keyspace.                                                                 | false    |           |
+| `tabletType` | The tabletType specifies a VTGate tablet type.                                                            | false    | `primary` |


### PR DESCRIPTION
### Description

- Add `keyspace` and `tabletType` parameters to the README.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-s3/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
