### PR TITLE
Update `source.Position` structure and tests

### DIFF
--- a/source/iterator/position.go
+++ b/source/iterator/position.go
@@ -43,27 +43,9 @@ type Position struct {
 	// The iterator will continue reading from the element if it's not empty.
 	// Mode: snapshot, cdc.
 	LastProcessedElementValue any `json:"last_processed_element_value,omitempty"`
-	// Gtid is the most recent gtid to start with.
-	// Mode: cdc.
-	Gtid string `json:"gtid,omitempty"`
 	// ShardGtids holds a list of shards which the connector will read events from.
 	// Mode: cdc.
 	ShardGtids []*binlogdata.ShardGtid `json:"shard_gtids,omitempty"`
-}
-
-// GetBinlogShardGtids returns Position's ShardGtids and
-// sets the ShardGtids's Gtid field to the Position's Gtid which is the most recent Gtid.
-func (p *Position) GetBinlogShardGtids() []*binlogdata.ShardGtid {
-	if len(p.ShardGtids) == 0 {
-		return nil
-	}
-
-	// make sure that all shard gtids have the most current gtid.
-	for i := 0; i < len(p.ShardGtids); i++ {
-		p.ShardGtids[i].Gtid = p.Gtid
-	}
-
-	return p.ShardGtids
 }
 
 // MarshalSDKPosition marshals the underlying position into a sdk.Position as JSON bytes.


### PR DESCRIPTION
### Description

This PR:

- Updates the `source.Position` structure, removes the `Gtid` field from it
- Updates source and destination tests 

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-s3/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
